### PR TITLE
Changed InspectionDecision_Retry to InspectionDecision_Reconnect when…

### DIFF
--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -214,7 +214,7 @@ func (s *subscriptionBase) InspectPackage(p *client.Package) (*client.Inspection
 					masterInfo.GetExternalTcpPort()))
 				secureTcpEndpoint, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d",
 					masterInfo.GetExternalSecureTcpAddress(), masterInfo.GetExternalSecureTcpPort()))
-				return client.NewInspectionResult(client.InspectionDecision_Retry, "NotHandled - NotMaster",
+				return client.NewInspectionResult(client.InspectionDecision_Reconnect, "NotHandled - NotMaster",
 					tcpEndpoint, secureTcpEndpoint), nil
 			default:
 				log.Errorf("Unknown NotHandledReason: %s.", dto.Reason)


### PR DESCRIPTION
… NotHandled - NotMaster

This fixes a bug which panics the library when the server response is NotHandled_NotMaster and the inspection decision is set to InspectionDecision_Retry rather than InspectionDecision_Reconnect.